### PR TITLE
Allow prefixing a house number with 'Number' and the like

### DIFF
--- a/tests/AddressSplitterTest.php
+++ b/tests/AddressSplitterTest.php
@@ -623,7 +623,59 @@ class AddressSplitterTest extends \PHPUnit_Framework_TestCase
                     ),
                     'additionToAddress2' => '8th Floor App. C'
                 )
-            )
+            ),
+            array(
+                'Beispielstraße, Nr 12',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Beispielstraße',
+                    'houseNumber'        => '12',
+                    'houseNumberParts'   => array(
+                        'base' => '12',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'Beispielstraße Nr. 12',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Beispielstraße',
+                    'houseNumber'        => '12',
+                    'houseNumberParts'   => array(
+                        'base' => '12',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'No. 10 Drowning Street',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Drowning Street',
+                    'houseNumber'        => '10',
+                    'houseNumberParts'   => array(
+                        'base' => '10',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => ''
+                )
+            ),
+            array(
+                'Beispielstraße Nr 12 WG Nr 13',
+                array(
+                    'additionToAddress1' => '',
+                    'streetName'         => 'Beispielstraße',
+                    'houseNumber'        => '12',
+                    'houseNumberParts'   => array(
+                        'base' => '12',
+                        'extension' => ''
+                    ),
+                    'additionToAddress2' => 'WG Nr 13'
+                )
+            ),
         );
     }
 


### PR DESCRIPTION
Also allows adding such number prefixes after additional address
information introducers (e.g., "APT No. 12").

Resolves: <https://github.com/pickware/AddressSplitting/issues/25>